### PR TITLE
Add simple bench for preact and cleanup single entry run js console log

### DIFF
--- a/examples/parcel-recipies-preact/.gitignore
+++ b/examples/parcel-recipies-preact/.gitignore
@@ -1,0 +1,2 @@
+dist-parcel/
+dist-webpack/

--- a/examples/parcel-recipies-preact/run.js
+++ b/examples/parcel-recipies-preact/run.js
@@ -3,6 +3,8 @@ const webpack = require("webpack");
 const path = require("path");
 const Benchmark = require("benchmark");
 
+process.env.NODE_ENV = "production";
+
 const exampleName = path.basename(__dirname);
 
 const defaultConfig = require("../../webpack.config")({ example: exampleName });

--- a/examples/parcel-recipies-preact/run.js
+++ b/examples/parcel-recipies-preact/run.js
@@ -1,9 +1,11 @@
 const Bundler = require("parcel-bundler");
 const webpack = require("webpack");
+const fs = require("fs");
 const path = require("path");
 const Benchmark = require("benchmark");
+const { humanifyCycleStats } = require("../util");
 
-process.env.NODE_ENV = "production";
+// process.env.NODE_ENV = "production";
 
 const exampleName = path.basename(__dirname);
 
@@ -40,13 +42,13 @@ suite
     }
   )
   .on("cycle", function(event) {
-    output.push(String(event.target));
+    output.push(humanifyCycleStats(__dirname, event));
   })
   .on("complete", function() {
-    output.forEach(element => {
-      console.log(element);
+    output.forEach(entry => {
+      console.log(`${entry.bundler}: ${entry.buildTime} | ${entry.buildSize}`);
     });
-    console.log("Fastest is " + this.filter("fastest").map("name"));
+    console.log(`Fastest is ${this.filter("fastest").map("name")}.`);
     process.exit(0);
   })
   .run({ async: true });

--- a/examples/parcel-recipies-preact/run.js
+++ b/examples/parcel-recipies-preact/run.js
@@ -6,7 +6,7 @@ const Benchmark = require("benchmark");
 const exampleName = path.basename(__dirname);
 
 const defaultConfig = require("../../webpack.config")({ example: exampleName });
-const index = path.join(__dirname, "src", "index.js");
+const index = path.join(__dirname, "src", "index.jsx");
 const suite = new Benchmark.Suite();
 let output = [];
 suite

--- a/examples/single-entry-med-graph-js-only/run.js
+++ b/examples/single-entry-med-graph-js-only/run.js
@@ -3,6 +3,8 @@ const webpack = require("webpack");
 const path = require("path");
 const Benchmark = require("benchmark");
 
+process.env.NODE_ENV = "production";
+
 const exampleName = path.basename(__dirname);
 
 const defaultConfig = require("../../webpack.config")({ example: exampleName });

--- a/examples/single-entry-med-graph-js-only/run.js
+++ b/examples/single-entry-med-graph-js-only/run.js
@@ -1,9 +1,11 @@
 const Bundler = require("parcel-bundler");
 const webpack = require("webpack");
+const fs = require("fs");
 const path = require("path");
 const Benchmark = require("benchmark");
+const { humanifyCycleStats } = require("../util");
 
-process.env.NODE_ENV = "production";
+// process.env.NODE_ENV = "production";
 
 const exampleName = path.basename(__dirname);
 
@@ -40,13 +42,13 @@ suite
     }
   )
   .on("cycle", function(event) {
-    output.push(String(event.target));
+    output.push(humanifyCycleStats(__dirname, event));
   })
   .on("complete", function() {
-    output.forEach(element => {
-      console.log(element);
+    output.forEach(entry => {
+      console.log(`${entry.bundler}: ${entry.buildTime} | ${entry.buildSize}`);
     });
-    console.log("Fastest is " + this.filter("fastest").map("name"));
+    console.log(`Fastest is ${this.filter("fastest").map("name")}.`);
     process.exit(0);
   })
   .run({ async: true });

--- a/examples/util.js
+++ b/examples/util.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const path = require("path");
+const filesize = require("file-size");
+
+function getFolderSize(dir) {
+  const files = fs.readdirSync(dir);
+
+  let totalSize = 0;
+  for (let i = 0; i < files.length; i++) {
+    const stats = fs.statSync(path.join(dir, files[i]));
+    if (stats.isFile()) {
+      totalSize += stats.size;
+    }
+  }
+  return totalSize;
+}
+
+function humanifyCycleStats(sampleDirectory, event) {
+  const name = event.target.name;
+  const stats = event.target.stats;
+  let mean = stats.mean;
+  let unit = "s";
+  if (mean < 1) {
+    mean = mean * 1000;
+    unit = "ms";
+  }
+  mean = mean.toFixed(2);
+  const distDir = path.join(sampleDirectory, `dist-${name}`);
+  const dirSize = getFolderSize(distDir);
+  return {
+    bundler: name,
+    buildTime: `${mean}${unit}`,
+    buildSize: filesize(dirSize).human()
+  };
+}
+module.exports = {
+  getFolderSize,
+  humanifyCycleStats
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
       "webpack --mode production --env.example parcel-recipies-preact",
     "build:parcel1":
       "parcel build ./examples/parcel-recipies-preact/src -d ./examples/parcel-recipies-preact/dist",
-    "bench:1": "node ./examples/single-entry-med-graph-js-only/run.js"
+    "bench:1": "node ./examples/single-entry-med-graph-js-only/run.js",
+    "bench:2": "node ./examples/parcel-recipies-preact/run.js"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -14,19 +14,16 @@
     "webpack": "webpack/webpack#next"
   },
   "scripts": {
-    "build:webpack":
-      "webpack --mode production --env.example single-entry-med-graph-js-only",
-    "build:parcel":
-      "parcel build ./examples/single-entry-med-graph-js-only/src/index.js -d ./examples/single-entry-med-graph-js-only/dist",
-    "build:webpack1":
-      "webpack --mode production --env.example parcel-recipies-preact",
-    "build:parcel1":
-      "parcel build ./examples/parcel-recipies-preact/src -d ./examples/parcel-recipies-preact/dist",
+    "build:webpack": "webpack --mode production --env.example single-entry-med-graph-js-only",
+    "build:parcel": "parcel build ./examples/single-entry-med-graph-js-only/src/index.js -d ./examples/single-entry-med-graph-js-only/dist",
+    "build:webpack1": "webpack --mode production --env.example parcel-recipies-preact",
+    "build:parcel1": "parcel build ./examples/parcel-recipies-preact/src -d ./examples/parcel-recipies-preact/dist",
     "bench:1": "node ./examples/single-entry-med-graph-js-only/run.js",
     "bench:2": "node ./examples/parcel-recipies-preact/run.js"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",
+    "file-size": "^1.0.0",
     "webpack-cli": "^1.5.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2023,6 +2023,10 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+file-size@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-size/-/file-size-1.0.0.tgz#3338267d5d206bbf60f4df60c19d7ed3813a4657"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"


### PR DESCRIPTION
Initial run results: (they're basically head in head, but that may be a config thing)
```
parcel x 17.06 ops/sec ±27.79% (56 runs sampled)
webpack x 17.26 ops/sec ±17.11% (50 runs sampled)
Fastest is webpack
```